### PR TITLE
Create assembler type that can be stepped through

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,6 @@ configurations {
 }
 
 dependencies {
-    implementation 'org.scala-lang:scala-library:2.13.4'
-    implementation 'org.clapper:grizzled-slf4j_2.13:1.3.4'
-
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
     testImplementation sourceSets.main.output
 

--- a/src/compiletest/java/mrtjp/fengine/testcases/FabricationBasicTest.java
+++ b/src/compiletest/java/mrtjp/fengine/testcases/FabricationBasicTest.java
@@ -21,6 +21,11 @@ public class FabricationBasicTest {
         this.scenario = scenario;
     }
 
+    // Override point to test other assemblers
+    protected ICAssembler createAssembler() {
+        return FabricationEngine.newAssembler();
+    }
+
     @FabricationTest (order = 0)
     public void testValidateScenario() {
 
@@ -31,7 +36,7 @@ public class FabricationBasicTest {
     public void testPrimaryAssembly() {
         System.out.println("Initializing test scenario...");
 
-        ICAssembler assembler = FabricationEngine.newAssembler();
+        ICAssembler assembler = createAssembler();
 
         // Start assembly at the root map
         scenario.init();

--- a/src/compiletest/java/mrtjp/fengine/testcases/FabricationSteppedAssemblerTest.java
+++ b/src/compiletest/java/mrtjp/fengine/testcases/FabricationSteppedAssemblerTest.java
@@ -1,0 +1,18 @@
+package mrtjp.fengine.testcases;
+
+import mrtjp.fengine.api.ICAssembler;
+import mrtjp.fengine.assemble.ICStepThroughAssemblerImpl;
+import mrtjp.fengine.framework.api.FabricationTestClass;
+
+@FabricationTestClass
+public class FabricationSteppedAssemblerTest extends FabricationBasicTest {
+
+    public FabricationSteppedAssemblerTest(FabricationTestScenario scenario) {
+        super(scenario);
+    }
+
+    @Override
+    protected ICAssembler createAssembler() {
+        return new ICStepThroughAssemblerImpl();
+    }
+}

--- a/src/main/java/mrtjp/fengine/api/ICAssembler.java
+++ b/src/main/java/mrtjp/fengine/api/ICAssembler.java
@@ -25,7 +25,5 @@ public interface ICAssembler {
     void addTileMap(FETileMap map, Map<Integer, Integer> remaps);
     void addFlatMap(ICFlatMap flatMap, Map<Integer, Integer> remaps);
 
-    int getMapIndex();
-
     ICFlatMap result();
 }

--- a/src/main/java/mrtjp/fengine/api/ICStepThroughAssembler.java
+++ b/src/main/java/mrtjp/fengine/api/ICStepThroughAssembler.java
@@ -1,0 +1,54 @@
+package mrtjp.fengine.api;
+
+import mrtjp.fengine.TileCoord;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ICStepThroughAssembler extends ICAssembler, Stepper {
+
+    void setEventReceiver(EventReceiver receiver);
+
+    enum AssemblerStepType {
+        CHECK_OPEN_TILE_MAPS,
+        CHECK_OPEN_FLAT_MAPS,
+        MERGE_TILE_MAP,
+        MERGE_FLAT_MAP,
+
+        MERGE_TILE_MAP_PRE,
+        MERGE_TILE_MAP_PHASE1,
+            PHASE1_ALLOC,
+        MERGE_TILE_MAP_PHASE2,
+            PHASE2_PATHFIND,
+            PHASE2_REGISTER_REMAPS,
+        MERGE_TILE_MAP_PHASE3,
+            PHASE3_CONSUME_REMAPS,
+        MERGE_TILE_MAP_PHASE4,
+            PHASE4_COLLECT,
+        MERGE_TILE_MAP_POST
+    }
+
+    interface AssemblerStepDescriptor {
+
+        AssemblerStepType getStepType();
+        List<Integer> getTreePath();
+    }
+
+    interface AssemblerStepResult {
+
+        AssemblerStepType getStepType();
+        List<Integer> getTreePath();
+
+        List<TileCoord> getTileCoords();
+        List<Integer> getRegisterIds();
+        List<Integer> getGateIds();
+        Map<Integer, Integer> getRemappedRegisterIds();
+    }
+
+    interface EventReceiver {
+
+        void onStepAdded(AssemblerStepDescriptor descriptor);
+
+        void onStepExecuted(AssemblerStepResult result);
+    }
+}

--- a/src/main/java/mrtjp/fengine/api/Stepper.java
+++ b/src/main/java/mrtjp/fengine/api/Stepper.java
@@ -1,0 +1,16 @@
+package mrtjp.fengine.api;
+
+public interface Stepper {
+
+    void stepOver();
+
+    void stepIn();
+
+    void stepOut();
+
+    int stepsRemaining();
+
+    default boolean isDone() {
+        return stepsRemaining() == 0;
+    }
+}

--- a/src/main/java/mrtjp/fengine/assemble/ICStepThroughAssemblerImpl.java
+++ b/src/main/java/mrtjp/fengine/assemble/ICStepThroughAssemblerImpl.java
@@ -1,0 +1,489 @@
+package mrtjp.fengine.assemble;
+
+import mrtjp.fengine.TileCoord;
+import mrtjp.fengine.api.ICAssemblyTile;
+import mrtjp.fengine.api.ICFlatMap;
+import mrtjp.fengine.api.ICStepThroughAssembler;
+import mrtjp.fengine.simulate.ICGate;
+import mrtjp.fengine.simulate.ICRegister;
+import mrtjp.fengine.tiles.FETileMap;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static mrtjp.fengine.api.ICStepThroughAssembler.AssemblerStepType.*;
+
+public class ICStepThroughAssemblerImpl implements ICStepThroughAssembler, ICFlatMap {
+
+    private final StepTree<AssemblerStepType, AssemblerStepResult> tree = new StepTree<>(new StepTreeEventReceiver());
+
+    private final Map<Integer, ICRegister> registers = new HashMap<>();
+    private final Map<Integer, ICGate> gates = new HashMap<>();
+
+    private final Map<Integer, ArrayList<Integer>> regDependents = new HashMap<>();    //[regID -> Seq[gateID]]
+    private final Map<Integer, ArrayList<Integer>> regDependencies = new HashMap<>();  //[regID -> Seq[gateID]]
+    private final Map<Integer, ArrayList<Integer>> gateDependents = new HashMap<>();   //[gateID -> Seq[regID]]
+    private final Map<Integer, ArrayList<Integer>> gateDependencies = new HashMap<>(); //[gateID -> Seq[regID]]
+
+    private final List<FETileMap> exploredTileMaps = new ArrayList<>();
+    private final List<ICFlatMap> exploredFlatMaps = new ArrayList<>();
+
+    private final Queue<TileMapRemapPair> openTileMaps = new LinkedList<>();
+    private final Queue<FlatMapRemapPair> openFlatMaps = new LinkedList<>();
+
+    private final Map<Integer, Integer> registerIDRemaps = new HashMap<>();
+
+    private int nextRegID = 0;
+    private int nextGateID = 0;
+
+    private ICStepThroughAssembler.EventReceiver eventReceiver = null;
+
+    @Override
+    public int allocRegisterID() {
+        return nextRegID++;
+    }
+
+    @Override
+    public int allocGateID() {
+        return nextGateID++;
+    }
+
+    @Override
+    public int allocRegisterID(int id) {
+        if (id >= nextRegID) nextRegID = id + 1;
+        return id;
+    }
+
+    @Override
+    public int allocGateID(int id) {
+        if (id >= nextGateID) nextGateID = id + 1;
+        return id;
+    }
+
+    @Override
+    public int getRemappedRegisterID(int id) {
+        return registerIDRemaps.getOrDefault(id, id);
+    }
+
+    @Override
+    public void addRemap(int oldID, int newID) {
+        registerIDRemaps.put(oldID, getRemappedRegisterID(newID));
+    }
+
+    @Override
+    public void addRegister(int id, ICRegister r) {
+
+        if (registers.containsKey(id)) {
+            if (getMapIndex() == 0)
+                throw new IllegalArgumentException("Register ID " + id + " already exists");
+            else
+                return; // Duplicates are allowed in nested maps, but are ignored. They are expected to be remapped.
+        }
+
+        allocRegisterID(id);
+        registers.put(id, r);
+    }
+
+    @Override
+    public void addGate(int id, ICGate gate, List<Integer> drivingRegs, List<Integer> drivenRegs) {
+
+        if (gates.containsKey(id)) throw new IllegalArgumentException("Gate ID " + id + " already exists");
+
+        allocGateID(id);
+        gates.put(id, gate);
+
+        for (int regID : drivingRegs) {
+            regDependents.putIfAbsent(regID, new ArrayList<>());
+            regDependents.get(regID).add(id);
+        }
+
+        for (int regID : drivenRegs) {
+            regDependencies.putIfAbsent(regID, new ArrayList<>());
+            regDependencies.get(regID).add(id);
+        }
+
+        // TODO Below, id should not exist in either gateDependents nor gateDependencies.
+        //      The add to existing existing list logic is unnecessary. Should be replaced
+        //      with simply <list>.put(new ArrayList(<registers>));
+
+        gateDependents.putIfAbsent(id, new ArrayList<>());
+        gateDependents.get(id).addAll(drivenRegs);
+
+        gateDependencies.putIfAbsent(id, new ArrayList<>());
+        gateDependencies.get(id).addAll(drivingRegs);
+    }
+
+    @Override
+    public void addTileMap(FETileMap map, Map<Integer, Integer> remaps) {
+        openTileMaps.add(new TileMapRemapPair(map, remaps));
+    }
+
+    @Override
+    public void addFlatMap(ICFlatMap flatMap, Map<Integer, Integer> remaps) {
+        openFlatMaps.add(new FlatMapRemapPair(flatMap, remaps));
+    }
+
+    private void mergeTileMap(FETileMap map, Map<Integer, Integer> remaps) {
+
+        tree.addStep(MERGE_TILE_MAP_PRE, () -> {
+            System.out.println("Assembly merge tile map setup");
+            registerIDRemaps.clear();
+            registerIDRemaps.putAll(remaps);
+            return new AssemblerStepResult(); // TODO: Return something useful
+        });
+
+        Collection<FETileMap.TileMapEntry> entries = map.getEntries();
+
+        // Phase 1: Allocate registers and compute nodes
+        tree.addStep(MERGE_TILE_MAP_PHASE1, () -> {
+            System.out.println("Assembly Phase 1: Allocations");
+            for (FETileMap.TileMapEntry entry : entries) {
+                tree.addStep(PHASE1_ALLOC, () -> {
+                    CachedAllocator allocator = new CachedAllocator();
+                    entry.getTile().allocate(allocator);
+                    return new AssemblerStepResult(entry.getCoord(), allocator.registerIds, allocator.gateIds);
+                });
+            }
+            return new AssemblerStepResult(); //TODO: Return something useful
+        });
+
+        // Phase 2: Pathfinding and remap assignment
+        tree.addStep(MERGE_TILE_MAP_PHASE2, () -> {
+            System.out.println("Assembly Phase 2: Pathfinding and remap declarations");
+            for (FETileMap.TileMapEntry entry : entries) {
+                tree.addStep(PHASE2_PATHFIND, () -> {
+                    System.out.println("Pathfinding at " + entry.getCoord());
+                    PathFinder pathFinder = new PathFinder(map, entry.getCoord());
+                    entry.getTile().locate(pathFinder);
+
+                    return new AssemblerStepResult(entry.getCoord()); //TODO: add pathfinding result
+                });
+
+                tree.addStep(PHASE2_REGISTER_REMAPS, () -> {
+                    Map<Integer, Integer> registeredRemaps = new HashMap<>();
+                    entry.getTile().registerRemaps((a, b) -> {
+                        registeredRemaps.put(a, b);
+                        this.addRemap(a, b);
+                    });
+                    return new AssemblerStepResult(entry.getCoord(), registeredRemaps); // TODO: Add located registers to result
+                });
+            }
+
+            return new AssemblerStepResult(); //TODO: Return something useful
+        });
+
+        // Phase 3: Remapping
+        tree.addStep(MERGE_TILE_MAP_PHASE3, () -> {
+            System.out.println("Assembly Phase 3: Remapping");
+            for (FETileMap.TileMapEntry entry : entries) {
+                tree.addStep(PHASE3_CONSUME_REMAPS, () -> {
+                    Map<Integer, Integer> consumedRemaps = new HashMap<>();
+                    entry.getTile().consumeRemaps(a -> {
+                        int b = ICStepThroughAssemblerImpl.this.getRemappedRegisterID(a);
+                        consumedRemaps.put(a, b);
+                        return b;
+                    });
+                    return new AssemblerStepResult(entry.getCoord(), consumedRemaps); // TODO: Add remaps to result
+                });
+            }
+            return new AssemblerStepResult(); //TODO: Return something useful
+        });
+
+        // Phase 4: Collect
+        tree.addStep(MERGE_TILE_MAP_PHASE4, () -> {
+            System.out.println("Assembly Phase 4: Register and Gate collection");
+            for (FETileMap.TileMapEntry entry : entries) {
+
+                tree.addStep(PHASE4_COLLECT, () -> {
+                    CachedCollector collector = new CachedCollector();
+                    entry.getTile().collect(collector);
+                    return new AssemblerStepResult(entry.getCoord(), collector.registerIds, collector.gateIds); // TODO: Return something useful
+                });
+            }
+
+            return new AssemblerStepResult(); //TODO: Return something useful
+        });
+
+        tree.addStep(MERGE_TILE_MAP_POST, () -> {
+            System.out.println("Assembly merge tile map cleanup");
+            registerIDRemaps.clear();
+            exploredTileMaps.add(map);
+            return new AssemblerStepResult(); //TODO: Return something useful
+        });
+    }
+
+    private void mergeFlatMap(ICFlatMap map, Map<Integer, Integer> remaps) {
+        Map<Integer, Integer> gateTransforms = new HashMap<>();
+        Map<Integer, Integer> regTransforms = new HashMap<>();
+
+        // Allocate new IDs for all registers in this address space besides those with explicit remaps
+        for (Map.Entry<Integer, ICRegister> e : map.getRegisters().entrySet()) {
+            int oldId = e.getKey();
+            int newId = remaps.getOrDefault(oldId, allocRegisterID()); // Use remap if available, else alloc new
+            regTransforms.put(oldId, newId);
+        }
+
+        // Allocate new IDs for all gates in this address space
+        for (Map.Entry<Integer, ICGate> e : map.getGates().entrySet()) {
+            int oldId = e.getKey();
+            int newId = allocGateID(); // Gates always get assigned a new id (they are never statically assigned)
+            gateTransforms.put(oldId, newId);
+        }
+
+        // Copy in registers to remapped addresses
+        for (Map.Entry<Integer, ICRegister> e : map.getRegisters().entrySet()) {
+            int oldId = e.getKey();
+            int newId = regTransforms.get(oldId);
+            if (!registers.containsKey(newId)) {
+                addRegister(newId, e.getValue());
+            }
+        }
+
+        // Copy in gates and remap their read/write lists
+        for (Map.Entry<Integer, ICGate> e : map.getGates().entrySet()) {
+            int oldId = e.getKey();
+            int newId = gateTransforms.get(oldId);
+
+            List<Integer> newDriving = map.getGateDependencies().get(oldId).stream()
+                    .map(regTransforms::get)
+                    .collect(Collectors.toList());
+            List<Integer> newDriven = map.getGateDependents().get(oldId).stream()
+                    .map(regTransforms::get)
+                    .collect(Collectors.toList());
+
+            addGate(newId, e.getValue(), newDriving, newDriven);
+        }
+
+        exploredFlatMaps.add(map);
+    }
+
+    private AssemblerStepResult checkOpenTileMapTask() {
+        // Merge next tile map
+        if (!openTileMaps.isEmpty()) {
+            TileMapRemapPair pair = openTileMaps.poll();
+            tree.addStep(MERGE_TILE_MAP, () -> {
+                mergeTileMap(pair.map, pair.remaps);
+                return new AssemblerStepResult(); // TODO: Return something useful
+            });
+
+            // Re-queue this task to merge additional tile maps
+            tree.addStep(CHECK_OPEN_TILE_MAPS, this::checkOpenTileMapTask);
+        } else {
+            // No more tile maps to merge, move to flat maps
+            tree.addStep(CHECK_OPEN_FLAT_MAPS, this::checkOpenFlatMapTask);
+        }
+
+        return new AssemblerStepResult(); // TODO: Return something useful
+    }
+
+    private AssemblerStepResult checkOpenFlatMapTask() {
+        // Merge next flat map
+        if (!openFlatMaps.isEmpty()) {
+            FlatMapRemapPair pair = openFlatMaps.poll();
+            tree.addStep(MERGE_FLAT_MAP, () -> {
+                mergeFlatMap(pair.map, pair.remaps);
+                return new AssemblerStepResult(); // TODO: Return something useful
+            });
+
+            // Re-queue this task if more flat maps remain
+            tree.addStep(CHECK_OPEN_FLAT_MAPS, this::checkOpenFlatMapTask);
+        }
+
+        return new AssemblerStepResult(); // TODO: Return something useful
+    }
+
+    @Override
+    public ICFlatMap result() {
+        tree.addStep(CHECK_OPEN_TILE_MAPS, this::checkOpenTileMapTask);
+
+        while (tree.stepsRemaining() > 0) tree.stepOver();
+
+        return this;
+    }
+
+    private int getMapIndex() {
+        return exploredFlatMaps.size() + exploredTileMaps.size();
+    }
+
+    private static class TileMapRemapPair {
+
+        FETileMap map;
+        Map<Integer, Integer> remaps;
+
+        public TileMapRemapPair(FETileMap map, Map<Integer, Integer> remaps) {
+            this.map = map;
+            this.remaps = remaps;
+        }
+    }
+
+    private static class FlatMapRemapPair {
+
+        ICFlatMap map;
+        Map<Integer, Integer> remaps;
+
+        public FlatMapRemapPair(ICFlatMap map, Map<Integer, Integer> remaps) {
+            this.map = map;
+            this.remaps = remaps;
+        }
+    }
+
+    private class StepTreeEventReceiver implements StepTree.StepTreeEventReceiver<AssemblerStepType, ICStepThroughAssemblerImpl.AssemblerStepResult> {
+
+        @Override
+        public void onStepExecuted(List<Integer> treePath, AssemblerStepType stepType, AssemblerStepResult stepResult) {
+            stepResult.setStepType(stepType);
+            stepResult.setTreePath(treePath);
+            if (eventReceiver != null) eventReceiver.onStepExecuted(stepResult);
+        }
+
+        @Override
+        public void onStepAdded(List<Integer> treePath, AssemblerStepType stepType) {
+            if (eventReceiver != null) eventReceiver.onStepAdded(new AssemblerStepDescriptor(stepType, treePath));
+        }
+    }
+
+    private class CachedAllocator implements ICAssemblyTile.Allocator {
+
+        public final List<Integer> registerIds = new LinkedList<>();
+        public final List<Integer> gateIds = new LinkedList<>();
+
+        @Override
+        public int allocRegisterID() {
+            int i = ICStepThroughAssemblerImpl.this.allocRegisterID();
+            registerIds.add(i);
+            return i;
+        }
+
+        @Override
+        public int allocRegisterID(int id) {
+            int i = ICStepThroughAssemblerImpl.this.allocRegisterID(id);
+            registerIds.add(i);
+            return i;
+        }
+
+        @Override
+        public int allocGateID() {
+            int i = ICStepThroughAssemblerImpl.this.allocGateID();
+            gateIds.add(i);
+            return i;
+        }
+
+        @Override
+        public int allocGateID(int id) {
+            int i = ICStepThroughAssemblerImpl.this.allocGateID(id);
+            gateIds.add(i);
+            return i;
+        }
+    }
+
+    private class CachedCollector implements ICAssemblyTile.Collector {
+
+        public final List<Integer> registerIds = new LinkedList<>();
+        public final List<Integer> gateIds = new LinkedList<>();
+
+        public int addedTileMapCount = 0;
+        public int addedFlatMapCount = 0;
+
+        @Override
+        public void addRegister(int id, ICRegister r) {
+            ICStepThroughAssemblerImpl.this.addRegister(id, r);
+            registerIds.add(id);
+        }
+
+        @Override
+        public void addGate(int id, ICGate gate, List<Integer> drivingRegs, List<Integer> drivenRegs) {
+            ICStepThroughAssemblerImpl.this.addGate(id, gate, drivingRegs, drivenRegs);
+            gateIds.add(id);
+        }
+
+        @Override
+        public void addTileMap(FETileMap map, Map<Integer, Integer> remaps) {
+            ICStepThroughAssemblerImpl.this.addTileMap(map, remaps);
+            addedTileMapCount++;
+        }
+
+        @Override
+        public void addFlatMap(ICFlatMap flatMap, Map<Integer, Integer> remaps) {
+            ICStepThroughAssemblerImpl.this.addFlatMap(flatMap, remaps);
+            addedFlatMapCount++;
+        }
+    }
+
+    private static class AssemblerStepDescriptor implements ICStepThroughAssembler.AssemblerStepDescriptor {
+
+        private final AssemblerStepType step;
+        private final List<Integer> treePath;
+
+        public AssemblerStepDescriptor(AssemblerStepType step, List<Integer> treePath) {
+            this.step = step;
+            this.treePath = treePath;
+        }
+
+        //@formatter:off
+        @Override public AssemblerStepType getStepType() { return step; }
+        @Override public List<Integer> getTreePath() { return treePath; }
+        //@formatter:on
+    }
+
+    private static class AssemblerStepResult implements ICStepThroughAssembler.AssemblerStepResult {
+
+        private AssemblerStepType step;
+        private List<Integer> treePath;
+
+        private final List<TileCoord> tileCoords;
+        private final List<Integer> registerIds;
+        private final List<Integer> gateIds;
+        private final Map<Integer, Integer> registerRemaps;
+
+        public AssemblerStepResult(List<TileCoord> tileCoords, List<Integer> registerIds, List<Integer> gateIds, Map<Integer, Integer> registerRemaps) {
+            this.tileCoords = tileCoords;
+            this.registerIds = registerIds;
+            this.gateIds = gateIds;
+            this.registerRemaps = registerRemaps;
+        }
+
+        public AssemblerStepResult() {
+            this(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
+        }
+
+        public AssemblerStepResult(TileCoord tileCoord) {
+            this(Collections.singletonList(tileCoord), Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
+        }
+
+        public AssemblerStepResult(TileCoord tileCoord, List<Integer> registerIds, List<Integer> gateIds) {
+            this(Collections.singletonList(tileCoord), registerIds, gateIds, Collections.emptyMap());
+        }
+
+        public AssemblerStepResult(TileCoord tileCoord, Map<Integer, Integer> registerRemaps) {
+            this(Collections.singletonList(tileCoord), Collections.emptyList(), Collections.emptyList(), registerRemaps);
+        }
+
+        //@formatter:off
+        public void setStepType(AssemblerStepType step) { this.step = step; }
+        public void setTreePath(List<Integer> treePath) { this.treePath = treePath; }
+        @Override public AssemblerStepType getStepType() { return step; }
+        @Override public List<Integer> getTreePath() { return treePath; }
+        @Override public List<TileCoord> getTileCoords() { return tileCoords; }
+        @Override public List<Integer> getRegisterIds() { return registerIds; }
+        @Override public List<Integer> getGateIds() { return gateIds; }
+        @Override public Map<Integer, Integer> getRemappedRegisterIds() { return registerRemaps; }
+        //@formatter:on
+    }
+
+    //@formatter:off
+    @Override public void setEventReceiver(EventReceiver receiver) { eventReceiver = receiver; }
+    @Override public void stepOver() { tree.stepOver(); }
+    @Override public void stepIn() { tree.stepIn(); }
+    @Override public void stepOut() { tree.stepOut(); }
+    @Override public int stepsRemaining() { return tree.stepsRemaining(); }
+
+    @Override public Map<Integer, ICRegister> getRegisters() { return registers; }
+    @Override public Map<Integer, ICGate> getGates() { return gates; }
+    @Override public Map<Integer, ArrayList<Integer>> getRegDependents() { return regDependents; }
+    @Override public Map<Integer, ArrayList<Integer>> getRegDependencies() { return regDependencies; }
+    @Override public Map<Integer, ArrayList<Integer>> getGateDependents() { return gateDependents; }
+    @Override public Map<Integer, ArrayList<Integer>> getGateDependencies() { return gateDependencies; }
+    @Override public List<FETileMap> getExploredTileMaps() { return exploredTileMaps; }
+    @Override public List<ICFlatMap> getExploredFlatMaps() { return exploredFlatMaps; }
+    //@formatter:on
+}

--- a/src/main/java/mrtjp/fengine/assemble/StepTree.java
+++ b/src/main/java/mrtjp/fengine/assemble/StepTree.java
@@ -1,0 +1,161 @@
+package mrtjp.fengine.assemble;
+
+import mrtjp.fengine.api.Stepper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Stack;
+import java.util.function.Supplier;
+
+public class StepTree<Descriptor, Result> implements Stepper {
+
+    private final Stack<StepTreeNode> stack = new Stack<>();
+    private final StepTreeEventReceiver<Descriptor, Result> receiver;
+
+    private int stepsRemaining = 0;
+
+    public StepTree(StepTreeEventReceiver<Descriptor, Result> receiver) {
+        this.receiver = receiver;
+        stack.push(new StepTreeNode());
+    }
+
+    public void addStep(Descriptor descriptor, Supplier<Result> task) {
+
+        stack.peek().createChild(descriptor, task);
+        stepsRemaining++;
+    }
+
+    @Override
+    public void stepOver() {
+
+        if (stepsRemaining == 0) return;
+
+        StepTreeNode target = stack.peek(); // Node to step over
+        if (target.isComplete()) {
+            if (!target.isRoot()) popAndSetExecuted();
+            return;
+        }
+
+        while (!target.isComplete()) {
+            StepTreeNode head = stack.peek();
+
+            if (!head.isComplete()) {
+                StepTreeNode next = head.getNextChildToExecute();
+                pushAndExecute(next);
+
+            } else {
+                popAndSetExecuted();
+            }
+        }
+    }
+
+    @Override
+    public void stepIn() {
+
+        if (stepsRemaining == 0) return;
+
+        StepTreeNode head = stack.peek();
+        if (head.isComplete()) {
+            if (!head.isRoot()) popAndSetExecuted();
+            return;
+        }
+
+        StepTreeNode next = head.getNextChildToExecute();
+        pushAndExecute(next);
+    }
+
+    @Override
+    public void stepOut() {
+
+        if (stepsRemaining == 0) return;
+
+        StepTreeNode head = stack.peek();
+
+        if (!head.isComplete()) stepOver();
+
+        if (!head.isRoot()) popAndSetExecuted();
+    }
+
+    @Override
+    public int stepsRemaining() {
+        return stepsRemaining;
+    }
+
+    private void pushAndExecute(StepTreeNode node) {
+        stack.push(node);
+        node.executeTask();
+        stepsRemaining--;
+    }
+
+    private void popAndSetExecuted() {
+        stack.pop();
+        stack.peek().setNextChildExecuted();
+    }
+
+    private class StepTreeNode {
+
+        private final List<StepTreeNode> children = new ArrayList<>();
+        private int completedChildren = 0;
+
+        private final Descriptor descriptor;
+        private final List<Integer> treePath;
+        private final Supplier<Result> task;
+
+        boolean taskExecuted = false;
+
+        public StepTreeNode(List<Integer> treePath, Descriptor descriptor, Supplier<Result> task) {
+            this.treePath = treePath;
+            this.descriptor = descriptor;
+            this.task = task;
+        }
+
+        public StepTreeNode() {
+            this(Collections.emptyList(), null, null);
+            taskExecuted = true; // Container only node. No actual task to execute.
+        }
+
+        public boolean isRoot() {
+            return treePath.isEmpty();
+        }
+
+        public void createChild(Descriptor descriptor, Supplier<Result> task) {
+
+            List<Integer> childTreePath = new ArrayList<>(treePath.size() + 1);
+            childTreePath.addAll(treePath);
+            childTreePath.add(children.size());
+
+            StepTreeNode child = new StepTreeNode(childTreePath, descriptor, task);
+            children.add(child);
+
+            receiver.onStepAdded(childTreePath, descriptor);
+        }
+
+        public StepTreeNode getNextChildToExecute() {
+            return children.get(completedChildren);
+        }
+
+        public void setNextChildExecuted() {
+            completedChildren++;
+        }
+
+        public void executeTask() {
+            if (taskExecuted) throw new RuntimeException("Task already executed");
+
+            Result result = task.get();
+            taskExecuted = true;
+            receiver.onStepExecuted(treePath, descriptor, result);
+        }
+
+        public boolean isComplete() {
+            return taskExecuted && completedChildren == children.size();
+        }
+    }
+
+    public interface StepTreeEventReceiver<Descriptor, Result> {
+
+        void onStepExecuted(List<Integer> treePath, Descriptor descriptor, Result result);
+
+        void onStepAdded(List<Integer> treePath, Descriptor descriptor);
+    }
+}

--- a/src/main/java/mrtjp/fengine/simulate/ICSimulation.java
+++ b/src/main/java/mrtjp/fengine/simulate/ICSimulation.java
@@ -14,6 +14,8 @@ public class ICSimulation {
 
     private Queue<Integer> changeQueue = new LinkedList<>();
 
+    private static final int[] EMPTY_INT_ARRAY = new int[0];
+
     public ICSimulation(
             Map<Integer, ICRegister> registerMap,
             Map<Integer, ICGate> gateMap,
@@ -21,11 +23,14 @@ public class ICSimulation {
             Map<Integer, ArrayList<Integer>> gateInputsMap,
             Map<Integer, ArrayList<Integer>> gateOutputsMap
     ) {
-        registers = expandIntoArray(registerMap);
-        gates = expandIntoArray(gateMap);
-        regDependents = expandIntoDoubleIntArray(registerDependentsMap);
-        gateInputs = expandIntoDoubleIntArray(gateInputsMap);
-        gateOutputs = expandIntoDoubleIntArray(gateOutputsMap);
+        int regCount = maxKey(registerMap) + 1;
+        int gateCount = maxKey(gateMap) + 1;
+
+        registers = expandIntoArray(registerMap, new ICRegister[regCount]);
+        gates = expandIntoArray(gateMap, new ICGate[gateCount]);
+        regDependents = expandIntoDoubleIntArray(registerDependentsMap, regCount);
+        gateInputs = expandIntoDoubleIntArray(gateInputsMap, gateCount);
+        gateOutputs = expandIntoDoubleIntArray(gateOutputsMap, gateCount);
     }
 
     public ICSimulation(ICFlatMap map) {
@@ -39,19 +44,18 @@ public class ICSimulation {
                 .orElse(0);
     }
 
-    @SuppressWarnings ("unchecked")
-    private static <T> T[] expandIntoArray(Map<Integer, T> map) {
-        T[] array = (T[]) new Object[maxKey(map)];
+    private static <T> T[] expandIntoArray(Map<Integer, T> map, T[] array) {
         for (Map.Entry<Integer, T> e : map.entrySet()) {
             array[e.getKey()] = e.getValue();
         }
         return array;
     }
 
-    private static int[][] expandIntoDoubleIntArray(Map<Integer, ArrayList<Integer>> map) {
-        int[][] array = new int[maxKey(map)][];
+    private static int[][] expandIntoDoubleIntArray(Map<Integer, ArrayList<Integer>> map, int length) {
+        int[][] array = new int[length][];
+        Arrays.fill(array, EMPTY_INT_ARRAY);
         for (Map.Entry<Integer, ArrayList<Integer>> e : map.entrySet()) {
-            array[e.getKey()] = e.getValue().stream().mapToInt(c -> c).toArray();
+            array[e.getKey()] = e.getValue().isEmpty() ? EMPTY_INT_ARRAY : e.getValue().stream().mapToInt(c -> c).toArray();
         }
         return array;
     }

--- a/src/main/java/mrtjp/fengine/tiles/FEPortlessGateTile.java
+++ b/src/main/java/mrtjp/fengine/tiles/FEPortlessGateTile.java
@@ -64,19 +64,19 @@ public abstract class FEPortlessGateTile implements FETile {
     }
 
     @Override
-    public void allocate(ICAssembler assembler) {
+    public void allocate(Allocator allocator) {
         Arrays.fill(inputRegisters, -1);
         Arrays.fill(outputRegisters, -1);
         gateId = -1;
 
         for (int dir = 0; dir < 6; dir++) {
-            if ((getOutDirMask() & 1 << dir) != 0) outputRegisters[dir] = assembler.allocRegisterID();
+            if ((getOutDirMask() & 1 << dir) != 0) outputRegisters[dir] = allocator.allocRegisterID();
         }
-        gateId = assembler.allocGateID();
+        gateId = allocator.allocGateID();
     }
 
     @Override
-    public void locate(ICAssembler assembler, PathFinder pathFinder) {
+    public void locate(PathFinder pathFinder) {
         for (int dir = 0; dir < 6; dir++) {
             if ((getInDirMask() & 1 << dir) != 0) {
                 int finalDir = dir;
@@ -92,22 +92,22 @@ public abstract class FEPortlessGateTile implements FETile {
     }
 
     @Override
-    public void remap(ICAssembler assembler) {
+    public void consumeRemaps(RemapProvider remapProvider) {
         for (int dir = 0; dir < 6; dir++) {
-            outputRegisters[dir] = assembler.getRemappedRegisterID(outputRegisters[dir]);
-            inputRegisters[dir] = assembler.getRemappedRegisterID(inputRegisters[dir]);
+            outputRegisters[dir] = remapProvider.getRemappedRegisterID(outputRegisters[dir]);
+            inputRegisters[dir] = remapProvider.getRemappedRegisterID(inputRegisters[dir]);
         }
     }
 
     @Override
-    public void collect(ICAssembler assembler) {
+    public void collect(Collector collector) {
         ArrayList<Integer> inputs = Arrays.stream(inputRegisters).filter(c -> c != -1).boxed().collect(Collectors.toCollection(ArrayList::new));
         ArrayList<Integer> outputs = Arrays.stream(outputRegisters).filter(c -> c != -1).boxed().collect(Collectors.toCollection(ArrayList::new));
 
         for (int dir = 0; dir < 6; dir++) {
-            if (outputRegisters[dir] != -1) assembler.addRegister(outputRegisters[dir], createRegister(dir));
+            if (outputRegisters[dir] != -1) collector.addRegister(outputRegisters[dir], createRegister(dir));
         }
         ICGate op = createGate(inputs, outputs);
-        assembler.addGate(gateId, op, inputs, outputs);
+        collector.addGate(gateId, op, inputs, outputs);
     }
 }

--- a/src/main/java/mrtjp/fengine/tiles/FEPortlessNestedFlatMapTile.java
+++ b/src/main/java/mrtjp/fengine/tiles/FEPortlessNestedFlatMapTile.java
@@ -1,6 +1,5 @@
 package mrtjp.fengine.tiles;
 
-import mrtjp.fengine.api.ICAssembler;
 import mrtjp.fengine.api.ICFlatMap;
 
 import java.util.Map;
@@ -22,8 +21,8 @@ public abstract class FEPortlessNestedFlatMapTile extends FEPortlessNestedMapTil
     }
 
     @Override
-    void addMapToAssembler(ICAssembler assembler, Map<Integer, Integer> remaps) {
-        assembler.addFlatMap(nestedFlatMap, remaps);
+    void addMapToAssembler(Collector collector, Map<Integer, Integer> remaps) {
+        collector.addFlatMap(nestedFlatMap, remaps);
     }
 
     //@formatter:off

--- a/src/main/java/mrtjp/fengine/tiles/FEPortlessNestedMapTile.java
+++ b/src/main/java/mrtjp/fengine/tiles/FEPortlessNestedMapTile.java
@@ -1,6 +1,5 @@
 package mrtjp.fengine.tiles;
 
-import mrtjp.fengine.api.ICAssembler;
 import mrtjp.fengine.assemble.PathFinder;
 import mrtjp.fengine.assemble.PathFinderResult;
 
@@ -45,11 +44,10 @@ public abstract class FEPortlessNestedMapTile implements FETile {
 
     /**
      * Override point for injecting the nested element into the assembler.
-     *
-     * @param assembler Receives the nested map
+     *  @param collector Receives the nested map
      * @param remaps    Remaps as determined by the signal maps above
      */
-    abstract void addMapToAssembler(ICAssembler assembler, Map<Integer, Integer> remaps);
+    abstract void addMapToAssembler(Collector collector, Map<Integer, Integer> remaps);
 
     @Override
     public Optional<Integer> getInputRegister(int inDir, int inPort) {
@@ -64,15 +62,15 @@ public abstract class FEPortlessNestedMapTile implements FETile {
     }
 
     @Override
-    public void allocate(ICAssembler assembler) {
+    public void allocate(Allocator allocator) {
         for (int dir = 0; dir < 6; dir++) {
-            outputRegisters[dir] = (getOutDirMask() & 1 << dir) != 0 ? assembler.allocRegisterID() : -1;
+            outputRegisters[dir] = (getOutDirMask() & 1 << dir) != 0 ? allocator.allocRegisterID() : -1;
             inputRegisters[dir] = -1;
         }
     }
 
     @Override
-    public void locate(ICAssembler assembler, PathFinder pathFinder) {
+    public void locate(PathFinder pathFinder) {
         for (int dir = 0; dir < 6; dir++) {
             if ((getInDirMask() & 1 << dir) != 0) {
                 int finalDir = dir;
@@ -88,15 +86,15 @@ public abstract class FEPortlessNestedMapTile implements FETile {
     }
 
     @Override
-    public void remap(ICAssembler assembler) {
+    public void consumeRemaps(RemapProvider remapProvider) {
         for (int dir = 0; dir < 6; dir++) {
-            outputRegisters[dir] = assembler.getRemappedRegisterID(outputRegisters[dir]);
-            inputRegisters[dir] = assembler.getRemappedRegisterID(inputRegisters[dir]);
+            outputRegisters[dir] = remapProvider.getRemappedRegisterID(outputRegisters[dir]);
+            inputRegisters[dir] = remapProvider.getRemappedRegisterID(inputRegisters[dir]);
         }
     }
 
     @Override
-    public void collect(ICAssembler assembler) {
+    public void collect(Collector collector) {
         Map<Integer, Integer> remaps = new HashMap<>();
 
         for (Map.Entry<Integer, Integer> e : getInputSignalMap().entrySet()) {
@@ -113,6 +111,6 @@ public abstract class FEPortlessNestedMapTile implements FETile {
             remaps.put(insideOutputReg, outsideOutputReg);
         }
 
-        addMapToAssembler(assembler, remaps);
+        addMapToAssembler(collector, remaps);
     }
 }

--- a/src/main/java/mrtjp/fengine/tiles/PortlessNestedTileMapTile.java
+++ b/src/main/java/mrtjp/fengine/tiles/PortlessNestedTileMapTile.java
@@ -1,7 +1,5 @@
 package mrtjp.fengine.tiles;
 
-import mrtjp.fengine.api.ICAssembler;
-
 import java.util.Map;
 
 public abstract class PortlessNestedTileMapTile extends FEPortlessNestedMapTile {
@@ -21,8 +19,8 @@ public abstract class PortlessNestedTileMapTile extends FEPortlessNestedMapTile 
     }
 
     @Override
-    void addMapToAssembler(ICAssembler assembler, Map<Integer, Integer> remaps) {
-        assembler.addTileMap(nestedTileMap, remaps);
+    void addMapToAssembler(Collector collector, Map<Integer, Integer> remaps) {
+        collector.addTileMap(nestedTileMap, remaps);
     }
 
     //@formatter:off

--- a/src/test/java/mrtjp/fengine/StepTreeTest.java
+++ b/src/test/java/mrtjp/fengine/StepTreeTest.java
@@ -1,0 +1,70 @@
+package mrtjp.fengine;
+
+import mrtjp.fengine.assemble.StepTree;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+public class StepTreeTest {
+
+    @Test
+    public void testStepOverExecutesAll() {
+
+        List<String> executedSteps = new LinkedList<>();
+        List<String> addedSteps = new LinkedList<>();
+
+        StepTree.StepTreeEventReceiver<String, Void> receiver = new StepTree.StepTreeEventReceiver<String, Void>() {
+            @Override
+            public void onStepExecuted(List<Integer> treePath, String descriptor, Void result) {
+                System.out.println("Step executed: " + descriptor);
+                executedSteps.add(descriptor);
+            }
+            @Override
+            public void onStepAdded(List<Integer> treePath, String descriptor) {
+                System.out.println("Step added: " + descriptor);
+                addedSteps.add(descriptor);
+            }
+        };
+
+        StepTree<String, Void> tree = new StepTree<>(receiver);
+
+        tree.addStep("1", () -> {
+            tree.addStep("1.1", () -> {
+                tree.addStep("1.1.1", () -> null);
+                return null;
+            });
+
+            tree.addStep("1.2", () -> null);
+            return null;
+        });
+
+        tree.addStep("2", () -> {
+            tree.addStep("2.1", () -> null);
+
+            tree.addStep("2.2", () -> {
+                tree.addStep("2.2.1", () -> null);
+                return null;
+            });
+            return null;
+        });
+
+        // Check initial conditions (2 steps added, none executed)
+        assertEquals(2, tree.stepsRemaining());
+        assertIterableEquals(Arrays.asList("1", "2"), addedSteps);
+        assertIterableEquals(Collections.emptyList(), executedSteps);
+
+        // Execute all steps
+        tree.stepOver();
+
+        // Check end conditions (0 steps remaining, all steps executed)
+        assertEquals(0, tree.stepsRemaining());
+        assertIterableEquals(Arrays.asList("1", "2", "1.1", "1.2", "1.1.1", "2.1", "2.2", "2.2.1"), addedSteps);
+        assertIterableEquals(Arrays.asList("1", "1.1", "1.1.1", "1.2", "2", "2.1", "2.2", "2.2.1"), executedSteps);
+    }
+}


### PR DESCRIPTION
This variant of the assembler can incrementally progress its operation. Uses include debugging, trading cpu load for compile time, etc.

* Split up the `ICAssembler` interface methods into separate classes per phase, as to enforce the functions being operated will only call phase-specific methods. This also makes it easy to probe step-specific changes.
* Implement step through compiler