### PR TITLE
Add compile phase for discovering signals that propagated through a tile

### DIFF
--- a/.github/workflows/verify-pull-request.yaml
+++ b/.github/workflows/verify-pull-request.yaml
@@ -56,7 +56,7 @@ jobs:
           java-version: '8'
 
       - name: Restore Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/src/compiletest/java/mrtjp/fengine/scenarios/SimpleOutputToInput.java
+++ b/src/compiletest/java/mrtjp/fengine/scenarios/SimpleOutputToInput.java
@@ -62,15 +62,22 @@ public class SimpleOutputToInput extends FabricationTestScenario {
         map.addTile(gateACoord, gateA);
 
         // Wires between A <--> B
+        PortlessWireTileImpl[] wires = new PortlessWireTileImpl[zDist];
         for (int i = 0; i < zDist; i++) {
             TileCoord wireCoord = new TileCoord(0, 0, z++);
-            map.addTile(wireCoord, new PortlessWireTileImpl(bitSouth | bitNorth));
+            wires[i] = new PortlessWireTileImpl(bitSouth | bitNorth);
+            map.addTile(wireCoord, wires[i]);
         }
 
         // Gate B
         TileCoord gateBCoord = new TileCoord(0, 0, z++);
         PortlessGateTileImpl gateB = new PortlessGateTileImpl("B", bitNorth, 0);
         map.addTile(gateBCoord, gateB);
+
+        // Wire registers
+        for (PortlessWireTileImpl wire : wires) {
+            addWireTileInput(wire, gateA.registers[dirSouth]);
+        }
 
         // Declare expected gates and registers
         setRootMap(map);

--- a/src/compiletest/java/mrtjp/fengine/testcases/FabricationBasicTest.java
+++ b/src/compiletest/java/mrtjp/fengine/testcases/FabricationBasicTest.java
@@ -9,6 +9,7 @@ import mrtjp.fengine.simulate.ICGate;
 import mrtjp.fengine.simulate.ICRegister;
 import mrtjp.fengine.simulate.ICSimulation;
 import mrtjp.fengine.testimpl.FabricationEngineTestImpl;
+import mrtjp.fengine.testimpl.PortlessWireTileImpl;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -119,6 +120,23 @@ public class FabricationBasicTest {
     }
 
     @FabricationTest (order = 6)
+    public void testWireInputs() {
+
+        Map<ICRegister, Integer> registerIDLookup = scenario.rootFlatMap.getRegisters().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+
+        for (Map.Entry<PortlessWireTileImpl, Set<ICRegister>> entry : scenario.wireTileDrivers.entrySet()) {
+
+            //Map set of ICRegisters to set of register IDs
+            Set<Integer> regIds = entry.getValue().stream()
+                    .map(registerIDLookup::get)
+                    .collect(Collectors.toSet());
+
+            assertEquals(entry.getKey().inputRegisters, regIds, "Wire's input list did not match expected");
+        }
+    }
+
+    @FabricationTest (order = 7)
     public void testFlatMapSerializationRoundTrip() {
 
         // Serialize the map
@@ -134,7 +152,7 @@ public class FabricationBasicTest {
         // TODO assert scenario.rootFlatMap == deserialized
     }
 
-    @FabricationTest (order = 7)
+    @FabricationTest (order = 8)
     public void testSimulationSerializationRoundTrip() {
 
         // Create simulation

--- a/src/compiletest/java/mrtjp/fengine/testcases/FabricationTestScenario.java
+++ b/src/compiletest/java/mrtjp/fengine/testcases/FabricationTestScenario.java
@@ -3,6 +3,7 @@ package mrtjp.fengine.testcases;
 import mrtjp.fengine.api.ICFlatMap;
 import mrtjp.fengine.simulate.ICGate;
 import mrtjp.fengine.simulate.ICRegister;
+import mrtjp.fengine.testimpl.PortlessWireTileImpl;
 import mrtjp.fengine.tiles.FEBasicTileMap;
 
 import java.util.HashSet;
@@ -18,6 +19,8 @@ public abstract class FabricationTestScenario {
     public FEBasicTileMap rootMap;
     public ICFlatMap rootFlatMap;
 
+    public Map<PortlessWireTileImpl, Set<ICRegister>> wireTileDrivers = new LinkedHashMap<>();
+
     public Set<ICGate> expectedGates = new HashSet<>();
     public Set<ICRegister> expectedRegisters = new HashSet<>();
 
@@ -32,6 +35,11 @@ public abstract class FabricationTestScenario {
 
     public void setRootMap(FEBasicTileMap rootMap) { this.rootMap = rootMap; }
 
+    //region TileMap validations
+    public void addWireTileInput(PortlessWireTileImpl wireTile, ICRegister register) { wireTileDrivers.computeIfAbsent(wireTile, k -> new HashSet<>()).add(register); }
+    //endregion
+
+    //region Flatmap validations
     public void addGate(ICGate gate) {
         expectedGates.add(gate);
         gateReads.computeIfAbsent(gate, k -> new HashSet<>());
@@ -42,6 +50,7 @@ public abstract class FabricationTestScenario {
 
     public void gateWritesToRegister(ICGate gate, ICRegister register) { gateWrites.get(gate).add(register); }
     public void gateReadsFromRegister(ICGate gate, ICRegister register) { gateReads.get(gate).add(register); }
+    //endregion
     //@formatter:on
 
     public abstract void init();

--- a/src/compiletest/java/mrtjp/fengine/testimpl/PortlessIOTileTestImpl.java
+++ b/src/compiletest/java/mrtjp/fengine/testimpl/PortlessIOTileTestImpl.java
@@ -1,6 +1,6 @@
 package mrtjp.fengine.testimpl;
 
-import mrtjp.fengine.assemble.PathFinder;
+import mrtjp.fengine.api.IPathFinder;
 import mrtjp.fengine.assemble.PathFinderResult;
 import mrtjp.fengine.simulate.StaticByteRegister;
 import mrtjp.fengine.tiles.FETile;
@@ -44,7 +44,7 @@ public class PortlessIOTileTestImpl implements FETile {
     }
 
     @Override
-    public void locate(PathFinder pathFinder) {
+    public void locate(IPathFinder pathFinder) {
         if (!isGlobalInput) { //Pathfinding only necessary for output IO tile, since they have an incoming register
             PathFinderResult pfr = pathFinder.doPathFinding((d, p) -> d == ioDir);
             if (pfr.inputRegisters.size() > 1) {

--- a/src/compiletest/java/mrtjp/fengine/testimpl/PortlessIOTileTestImpl.java
+++ b/src/compiletest/java/mrtjp/fengine/testimpl/PortlessIOTileTestImpl.java
@@ -47,11 +47,11 @@ public class PortlessIOTileTestImpl implements FETile {
     public void locate(IPathFinder pathFinder) {
         if (!isGlobalInput) { //Pathfinding only necessary for output IO tile, since they have an incoming register
             PathFinderResult pfr = pathFinder.doPathFinding((d, p) -> d == ioDir);
-            if (pfr.inputRegisters.size() > 1) {
-                System.out.println("ERR: Unexpected multiple drivers: " + pfr.inputRegisters);
+            if (pfr.outputRegisters.size() > 1) {
+                System.out.println("ERR: Unexpected multiple drivers: " + pfr.outputRegisters);
             }
-            if (!pfr.inputRegisters.isEmpty()) {
-                regId = pfr.inputRegisters.get(0);
+            if (!pfr.outputRegisters.isEmpty()) {
+                regId = pfr.outputRegisters.get(0);
             }
         }
     }

--- a/src/compiletest/java/mrtjp/fengine/testimpl/PortlessWireTileImpl.java
+++ b/src/compiletest/java/mrtjp/fengine/testimpl/PortlessWireTileImpl.java
@@ -1,13 +1,30 @@
 package mrtjp.fengine.testimpl;
 
+import mrtjp.fengine.api.IPathFinder;
+import mrtjp.fengine.api.IPathFinderManifest;
 import mrtjp.fengine.tiles.FEPortlessWireTile;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class PortlessWireTileImpl extends FEPortlessWireTile {
 
     private final int connMask;
 
+    public final Set<Integer> inputRegisters = new HashSet<>();
+
     public PortlessWireTileImpl(int connMask) {
         this.connMask = connMask;
+    }
+
+    @Override
+    public void locate(IPathFinder pathFinder) {
+        inputRegisters.clear();
+    }
+
+    @Override
+    public void searchManifest(IPathFinderManifest manifest) {
+        inputRegisters.addAll(manifest.getOutputRegisters()); // Found output registers feed into this wire as inputs
     }
 
     //@formatter:off

--- a/src/main/java/mrtjp/fengine/api/ICAssemblyTile.java
+++ b/src/main/java/mrtjp/fengine/api/ICAssemblyTile.java
@@ -1,6 +1,5 @@
 package mrtjp.fengine.api;
 
-import mrtjp.fengine.assemble.PathFinder;
 import mrtjp.fengine.simulate.ICGate;
 import mrtjp.fengine.simulate.ICRegister;
 import mrtjp.fengine.tiles.FETileMap;
@@ -36,10 +35,21 @@ public interface ICAssemblyTile {
      *
      * @param pathFinder Pathfinder to be used to locate input registers from the map
      */
-    default void locate(PathFinder pathFinder) { }
+    default void locate(IPathFinder pathFinder) { }
 
     /**
-     * Assembly pass 2:
+     * Assembly pass 3:
+     * <p>
+     * Search pathfinder manifest for any registers of interest. Typically, used by propagation-capable
+     * tiles to figure out which signals passed through them by peeking at pathfinding results of other
+     * tiles.
+     *
+     * @param manifest The manifest to search
+     */
+    default void searchManifest(IPathFinderManifest manifest) { }
+
+    /**
+     * Assembly pass 4:
      * <p>
      * Use provided remap registry to declare necessary remaps
      *
@@ -48,7 +58,7 @@ public interface ICAssemblyTile {
     default void registerRemaps(RemapRegistry remapRegistry) { }
 
     /**
-     * Assembly pass 3:
+     * Assembly pass 5:
      * <p>
      * Check all register IDs for remap and adjust to new value if necessary.
      *
@@ -57,7 +67,7 @@ public interface ICAssemblyTile {
     default void consumeRemaps(RemapProvider remapProvider) { }
 
     /**
-     * Assembly pass 4:
+     * Assembly pass 6:
      * <p>
      * Add registers and gates to the assembler
      *

--- a/src/main/java/mrtjp/fengine/api/ICStepThroughAssembler.java
+++ b/src/main/java/mrtjp/fengine/api/ICStepThroughAssembler.java
@@ -20,11 +20,14 @@ public interface ICStepThroughAssembler extends ICAssembler, Stepper {
             PHASE1_ALLOC,
         MERGE_TILE_MAP_PHASE2,
             PHASE2_PATHFIND,
-            PHASE2_REGISTER_REMAPS,
         MERGE_TILE_MAP_PHASE3,
-            PHASE3_CONSUME_REMAPS,
+            PHASE3_PF_MANIFEST_SEARCH,
         MERGE_TILE_MAP_PHASE4,
-            PHASE4_COLLECT,
+            PHASE4_REGISTER_REMAPS,
+        MERGE_TILE_MAP_PHASE5,
+            PHASE5_CONSUME_REMAPS,
+        MERGE_TILE_MAP_PHASE6,
+            PHASE6_COLLECT,
         MERGE_TILE_MAP_POST
     }
 

--- a/src/main/java/mrtjp/fengine/api/IPathFinder.java
+++ b/src/main/java/mrtjp/fengine/api/IPathFinder.java
@@ -1,0 +1,8 @@
+package mrtjp.fengine.api;
+
+import mrtjp.fengine.assemble.PathFinderResult;
+
+public interface IPathFinder {
+
+    PathFinderResult doPathFinding(PropagationFunction propagationFunc);
+}

--- a/src/main/java/mrtjp/fengine/api/IPathFinderManifest.java
+++ b/src/main/java/mrtjp/fengine/api/IPathFinderManifest.java
@@ -1,0 +1,12 @@
+package mrtjp.fengine.api;
+
+import java.util.Set;
+
+public interface IPathFinderManifest {
+
+    Set<Integer> getInputRegisters();
+    Set<Integer> getInputRegistersIntersectingMasks(int inputDirMask, int inputPortMask, int outputDirMask, int outputPortMask);
+
+    Set<Integer> getOutputRegisters();
+    Set<Integer> getOutputRegistersIntersectingMasks(int inputDirMask, int inputPortMask, int outputDirMask, int outputPortMask);
+}

--- a/src/main/java/mrtjp/fengine/assemble/PathFinder.java
+++ b/src/main/java/mrtjp/fengine/assemble/PathFinder.java
@@ -1,21 +1,26 @@
 package mrtjp.fengine.assemble;
 
 import mrtjp.fengine.TileCoord;
+import mrtjp.fengine.api.IPathFinder;
 import mrtjp.fengine.api.PropagationFunction;
 import mrtjp.fengine.tiles.FETileMap;
 
-public class PathFinder {
+import java.util.jar.Manifest;
+
+public class PathFinder implements IPathFinder {
 
     private final FETileMap map;
     private final TileCoord pos;
+    private final PathFinderManifest manifest;
 
-    public PathFinder(FETileMap map, TileCoord pos) {
+    public PathFinder(FETileMap map, TileCoord pos, PathFinderManifest manifest) {
         this.map = map;
         this.pos = pos;
+        this.manifest = manifest;
     }
 
     public PathFinderResult doPathFinding(PropagationFunction propagationFunc) {
-        TileMapPathFinder pf = new TileMapPathFinder(map, pos, propagationFunc);
+        TileMapPathFinder pf = new TileMapPathFinder(manifest, map, pos, propagationFunc);
         while (!pf.isFinished()) pf.step();
         return pf.result();
     }

--- a/src/main/java/mrtjp/fengine/assemble/PathFinderManifest.java
+++ b/src/main/java/mrtjp/fengine/assemble/PathFinderManifest.java
@@ -1,0 +1,96 @@
+package mrtjp.fengine.assemble;
+
+import mrtjp.fengine.TileCoord;
+import mrtjp.fengine.api.IPathFinderManifest;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class PathFinderManifest {
+
+    private final Map<TileCoord, ManifestEntry> manifestMap = new HashMap<>();
+
+    public void addInputPropagationTrail(int inputRegId, PathFinderNode node) {
+        node.forEachPropagation((pos, inDir, inPort, outDir, outPort) -> {
+            ManifestEntry entry = manifestMap.computeIfAbsent(pos, p -> new ManifestEntry());
+            entry.addInputPropagation(inputRegId, inDir, inPort, outDir, outPort);
+        });
+    }
+
+    public void addOutputPropagationTrail(int outputRegId, PathFinderNode node) {
+        node.forEachPropagation((pos, inDir, inPort, outDir, outPort) -> {
+            ManifestEntry entry = manifestMap.computeIfAbsent(pos, p -> new ManifestEntry());
+            entry.addOutputPropagation(outputRegId, inDir, inPort, outDir, outPort);
+        });
+    }
+
+    public ManifestEntry getManifest(TileCoord pos) {
+        return manifestMap.getOrDefault(pos, ManifestEntry.EMPTY);
+    }
+
+    public void clear() {
+        manifestMap.clear();
+    }
+
+    private static class ManifestEntry implements IPathFinderManifest {
+
+        private static final ManifestEntry EMPTY = new ManifestEntry();
+
+        private final Map<Integer, PropagationMask> inputRegisters = new HashMap<>();
+        private final Map<Integer, PropagationMask> outputRegisters = new HashMap<>();
+
+        public void addInputPropagation(int inputReg, int inputDir, int inputPort, int outputDir, int outputPort) {
+            PropagationMask mask = this.inputRegisters.computeIfAbsent(inputReg, r -> new PropagationMask());
+            mask.or(inputDir, inputPort, outputDir, outputPort);
+        }
+
+        public void addOutputPropagation(int outputReg, int inputDir, int inputPort, int outputDir, int outputPort) {
+            PropagationMask mask = this.outputRegisters.computeIfAbsent(outputReg, r -> new PropagationMask());
+            mask.or(inputDir, inputPort, outputDir, outputPort);
+        }
+
+        public Set<Integer> getInputRegisters() {
+            return inputRegisters.keySet();
+        }
+
+        public Set<Integer> getOutputRegisters() {
+            return outputRegisters.keySet();
+        }
+
+        public Set<Integer> getInputRegistersIntersectingMasks(int inputDirMask, int inputPortMask, int outputDirMask, int outputPortMask) {
+            return inputRegisters.entrySet().stream()
+                    .filter(e -> e.getValue().testMasks(inputDirMask, inputPortMask, outputDirMask, outputPortMask))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toSet());
+        }
+
+        public Set<Integer> getOutputRegistersIntersectingMasks(int inputDirMask, int inputPortMask, int outputDirMask, int outputPortMask) {
+            return outputRegisters.entrySet().stream()
+                    .filter(e -> e.getValue().testMasks(inputDirMask, inputPortMask, outputDirMask, outputPortMask))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toSet());
+        }
+    }
+
+    private static class PropagationMask {
+
+        private int inputDirMask = 0;
+        private int inputPortMask = 0;
+        private int outputDirMask = 0;
+        private int outputPortMask = 0;
+
+        public void or(int inputDir, int inputPort, int outputDir, int outputPort) {
+            inputDirMask |= 1 << inputDir;
+            inputPortMask |= 1 << inputPort;
+            outputDirMask |= 1 << outputDir;
+            outputPortMask |= 1 << outputPort;
+        }
+
+        public boolean testMasks(int inputDirMask, int inputPortMask, int outputDirMask, int outputPortMask) {
+            return (this.inputDirMask & inputDirMask) != 0 && (this.inputPortMask & inputPortMask) != 0 &&
+                    (this.outputDirMask & outputDirMask) != 0 && (this.outputPortMask & outputPortMask) != 0;
+        }
+    }
+}

--- a/src/main/java/mrtjp/fengine/assemble/TileMapPathFinder.java
+++ b/src/main/java/mrtjp/fengine/assemble/TileMapPathFinder.java
@@ -65,13 +65,13 @@ public class TileMapPathFinder { //TODO implement Stepper
         int port = prev.inputPort;
 
         tile.getOutputRegister(dir, port).ifPresent(outputRegID -> {
-            portToInputRegisters.computeIfAbsent(initialPort, i -> new HashSet<>()).add(outputRegID);
-            manifest.addInputPropagationTrail(outputRegID, prev);
+            portToOutputRegisters.computeIfAbsent(initialPort, i -> new HashSet<>()).add(outputRegID);
+            manifest.addOutputPropagationTrail(outputRegID, prev);
         });
 
         tile.getInputRegister(dir, port).ifPresent(inputRegID -> {
-            portToOutputRegisters.computeIfAbsent(initialPort, i -> new HashSet<>()).add(inputRegID);
-            manifest.addOutputPropagationTrail(inputRegID, prev);
+            portToInputRegisters.computeIfAbsent(initialPort, i -> new HashSet<>()).add(inputRegID);
+            manifest.addInputPropagationTrail(inputRegID, prev);
         });
     }
 

--- a/src/main/java/mrtjp/fengine/simulate/ICSimulation.java
+++ b/src/main/java/mrtjp/fengine/simulate/ICSimulation.java
@@ -23,8 +23,8 @@ public class ICSimulation {
             Map<Integer, ArrayList<Integer>> gateInputsMap,
             Map<Integer, ArrayList<Integer>> gateOutputsMap
     ) {
-        int regCount = maxKey(registerMap) + 1;
-        int gateCount = maxKey(gateMap) + 1;
+        int regCount = registerMap.isEmpty() ? 0 : maxKey(registerMap) + 1;
+        int gateCount = gateMap.isEmpty() ? 0 : maxKey(gateMap) + 1;
 
         registers = expandIntoArray(registerMap, new ICRegister[regCount]);
         gates = expandIntoArray(gateMap, new ICGate[gateCount]);

--- a/src/main/java/mrtjp/fengine/simulate/ICSimulation.java
+++ b/src/main/java/mrtjp/fengine/simulate/ICSimulation.java
@@ -78,8 +78,25 @@ public class ICSimulation {
         return registers[regID].getByteVal();
     }
 
+    public long getRegLongVal(int regID3, int regID2, int regID1, int regID0) {
+
+        long i = 0;
+        i |= (long) (getRegByteVal(regID3) & 0xFF) << 24;
+        i |= (long) (getRegByteVal(regID2) & 0xFF) << 16;
+        i |= (long) (getRegByteVal(regID1) & 0xFF) << 8;
+        i |= getRegByteVal(regID0) & 0xFF;
+        return i;
+    }
+
     public void queueRegByteVal(int regID, byte newVal) {
         if (registers[regID].queueByteVal(newVal)) { changeQueue.add(regID); }
+    }
+
+    public void queueRegLongVal(int regID3, int regID2, int regID1, int regID0, long newVal) {
+        queueRegByteVal(regID3, (byte) (newVal >> 24));
+        queueRegByteVal(regID2, (byte) (newVal >> 16));
+        queueRegByteVal(regID1, (byte) (newVal >> 8));
+        queueRegByteVal(regID0, (byte) (newVal));
     }
 
     public boolean propagate(ICSimulationCallback callback) {

--- a/src/main/java/mrtjp/fengine/tiles/FEPortlessGateTile.java
+++ b/src/main/java/mrtjp/fengine/tiles/FEPortlessGateTile.java
@@ -80,11 +80,11 @@ public abstract class FEPortlessGateTile implements FETile {
             if ((getInDirMask() & 1 << dir) != 0) {
                 int finalDir = dir;
                 PathFinderResult pfr = pathFinder.doPathFinding((d, p) -> d == finalDir);
-                if (pfr.inputRegisters.size() > 1) {
-                    System.out.println("ERR: Unexpected multiple drivers: " + pfr.inputRegisters);
+                if (pfr.outputRegisters.size() > 1) {
+                    System.out.println("ERR: Unexpected multiple drivers: " + pfr.outputRegisters);
                 }
-                if (!pfr.inputRegisters.isEmpty()) {
-                    inputRegisters[dir] = pfr.inputRegisters.get(0);
+                if (!pfr.outputRegisters.isEmpty()) {
+                    inputRegisters[dir] = pfr.outputRegisters.get(0);
                 }
             }
         }

--- a/src/main/java/mrtjp/fengine/tiles/FEPortlessGateTile.java
+++ b/src/main/java/mrtjp/fengine/tiles/FEPortlessGateTile.java
@@ -1,7 +1,6 @@
 package mrtjp.fengine.tiles;
 
-import mrtjp.fengine.api.ICAssembler;
-import mrtjp.fengine.assemble.PathFinder;
+import mrtjp.fengine.api.IPathFinder;
 import mrtjp.fengine.assemble.PathFinderResult;
 import mrtjp.fengine.simulate.ICGate;
 import mrtjp.fengine.simulate.ICRegister;
@@ -76,7 +75,7 @@ public abstract class FEPortlessGateTile implements FETile {
     }
 
     @Override
-    public void locate(PathFinder pathFinder) {
+    public void locate(IPathFinder pathFinder) {
         for (int dir = 0; dir < 6; dir++) {
             if ((getInDirMask() & 1 << dir) != 0) {
                 int finalDir = dir;

--- a/src/main/java/mrtjp/fengine/tiles/FEPortlessNestedMapTile.java
+++ b/src/main/java/mrtjp/fengine/tiles/FEPortlessNestedMapTile.java
@@ -1,6 +1,6 @@
 package mrtjp.fengine.tiles;
 
-import mrtjp.fengine.assemble.PathFinder;
+import mrtjp.fengine.api.IPathFinder;
 import mrtjp.fengine.assemble.PathFinderResult;
 
 import java.util.Arrays;
@@ -70,7 +70,7 @@ public abstract class FEPortlessNestedMapTile implements FETile {
     }
 
     @Override
-    public void locate(PathFinder pathFinder) {
+    public void locate(IPathFinder pathFinder) {
         for (int dir = 0; dir < 6; dir++) {
             if ((getInDirMask() & 1 << dir) != 0) {
                 int finalDir = dir;

--- a/src/main/java/mrtjp/fengine/tiles/FEPortlessNestedMapTile.java
+++ b/src/main/java/mrtjp/fengine/tiles/FEPortlessNestedMapTile.java
@@ -75,11 +75,11 @@ public abstract class FEPortlessNestedMapTile implements FETile {
             if ((getInDirMask() & 1 << dir) != 0) {
                 int finalDir = dir;
                 PathFinderResult pfr = pathFinder.doPathFinding((d, p) -> d == finalDir);
-                if (pfr.inputRegisters.size() > 1) {
-                    System.out.println("ERR: Unexpected multiple drivers: " + pfr.inputRegisters);
+                if (pfr.outputRegisters.size() > 1) {
+                    System.out.println("ERR: Unexpected multiple drivers: " + pfr.outputRegisters);
                 }
-                if (!pfr.inputRegisters.isEmpty()) {
-                    inputRegisters[dir] = pfr.inputRegisters.get(0);
+                if (!pfr.outputRegisters.isEmpty()) {
+                    inputRegisters[dir] = pfr.outputRegisters.get(0);
                 }
             }
         }


### PR DESCRIPTION
Allows tiles that do propagation (such as wires) to learn about the results of a path-finding operation performed between 2 other tiles. Not useful for simulation, but can be useful for rendering wire states and such.